### PR TITLE
Provide raw ctools_context in CTools\PluginContexts

### DIFF
--- a/includes/CTools/PluginContexts.inc
+++ b/includes/CTools/PluginContexts.inc
@@ -17,6 +17,10 @@ class PluginContexts {
    * @var PluginContext[]
    */
   private $contexts = [];
+  /**
+   * @var ctools_context[]
+   */
+  private $rawContexts = [];
 
   /**
    * PluginContexts constructor.
@@ -25,6 +29,7 @@ class PluginContexts {
    *   An array of contexts.
    */
   public function __construct($contexts) {
+    $this->rawContexts = $contexts;
     if (!is_array($contexts)) {
       $contexts = [$contexts];
     }
@@ -103,6 +108,15 @@ class PluginContexts {
     }
 
     return FALSE;
+  }
+
+  /**
+   * Get raw ctools context.
+   * 
+   * @return array|\ctools_context[]
+   */
+  public function getRawContexts() {
+    return $this->rawContexts;
   }
 
 }

--- a/includes/CTools/PluginContexts.inc
+++ b/includes/CTools/PluginContexts.inc
@@ -18,9 +18,9 @@ class PluginContexts {
    */
   private $contexts = [];
   /**
-   * @var ctools_context[]
+   * @var null|\ctools_context|\ctools_context[]
    */
-  private $rawContexts = [];
+  private $rawArgument;
 
   /**
    * PluginContexts constructor.
@@ -29,7 +29,7 @@ class PluginContexts {
    *   An array of contexts.
    */
   public function __construct($contexts) {
-    $this->rawContexts = $contexts;
+    $this->rawArgument = $contexts;
 
     if (!is_array($contexts)) {
       $contexts = [$contexts];
@@ -112,12 +112,13 @@ class PluginContexts {
   }
 
   /**
-   * Get raw ctools context.
+   * Get raw value of constructor argument.
    * 
-   * @return array|\ctools_context[]
+   * @return null|\ctools_context|\ctools_context[]
+   *   Raw argument from "ctools" module.
    */
-  public function getRawContexts() {
-    return $this->rawContexts;
+  public function getRawArgument() {
+    return $this->rawArgument;
   }
 
 }

--- a/includes/CTools/PluginContexts.inc
+++ b/includes/CTools/PluginContexts.inc
@@ -30,6 +30,7 @@ class PluginContexts {
    */
   public function __construct($contexts) {
     $this->rawContexts = $contexts;
+
     if (!is_array($contexts)) {
       $contexts = [$contexts];
     }


### PR DESCRIPTION
In my case:

```

    $mini_panel_object = panels_mini_load($panel_name);
      $mini_panel_object->display->args = $arguments;

      if (!empty($raw_context = $contexts->getRawContexts())) {
        ctools_include('context');
        $mini_panel_contexts = ctools_context_match_required_contexts($mini_panel_object->requiredcontexts, $raw_context);
        $mini_panel_object->context = $mini_panel_object->display->context =  ctools_context_load_contexts($mini_panel_object, FALSE, $mini_panel_contexts);
      }

      $variables['rows'][strtolower($mini_panel_object->admin_title)] = [
        'title' => $mini_panel_object->admin_title,
        'content' => panels_render_display($mini_panel_object->display),
      ];
```
